### PR TITLE
Added `message:swipe-deleted` event.

### DIFF
--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -586,6 +586,7 @@ export const useChatStore = defineStore('chat', () => {
     promptStore.clearItemizedPrompt(messageIndex, swipeIndex);
 
     const newSwipeId = Math.min(swipeIndex, message.swipes.length - 1);
+    await eventEmitter.emit('message:swipe-deleted', { messageIndex, swipeIndex, newSwipeId });
     await syncSwipeToMes(messageIndex, newSwipeId);
   }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -26,6 +26,7 @@ export interface ExtensionEventMap {
   'message:created': [message: ChatMessage];
   'message:updated': [index: number, message: ChatMessage];
   'message:deleted': [indices: number[]];
+  'message:swipe-deleted': [{ messageIndex:number, swipeIndex:number, newSwipeId:number }];
 
   // Character Events
   'character:created': [character: Character];


### PR DESCRIPTION
This is emitted after the swipe was deleted and before next swipe is synced.
This mirrors ST's behavior: https://github.com/SillyTavern/SillyTavern/blob/release/public/script.js#L8714