### PR TITLE
Added Extension icons.

### DIFF
--- a/src/components/NavBar/ExtensionsDrawer.vue
+++ b/src/components/NavBar/ExtensionsDrawer.vue
@@ -80,7 +80,7 @@ function handleClose() {
             @click="handleExtensionSelect(extension)"
           >
             <template #start>
-              <i class="fa-solid fa-puzzle-piece" style="opacity: 0.7"></i>
+              <i :class="extension.manifest.icon ?? 'fa-solid fa-puzzle-piece'" style="opacity: 0.7"></i>
             </template>
             <template #default>
               <div class="font-bold">{{ extension.manifest.display_name || extension.id }}</div>

--- a/src/extensions/built-in/chat-branching/manifest.ts
+++ b/src/extensions/built-in/chat-branching/manifest.ts
@@ -6,4 +6,5 @@ export const manifest: ExtensionManifest = {
   description: 'Adds an option to branch the chat from a specific message.',
   version: '1.0.0',
   author: 'NeoTavern Team',
+  icon: 'fa-solid fa-code-branch'
 };

--- a/src/extensions/built-in/chat-translation/manifest.ts
+++ b/src/extensions/built-in/chat-translation/manifest.ts
@@ -6,4 +6,5 @@ export const manifest: ExtensionManifest = {
   description: 'Translate chat messages using an LLM connection profile.',
   version: '1.0.0',
   author: 'NeoTavern Team',
+  icon: 'fa-solid fa-language'
 };

--- a/src/extensions/built-in/reroll-continue/manifest.ts
+++ b/src/extensions/built-in/reroll-continue/manifest.ts
@@ -6,4 +6,5 @@ export const manifest: ExtensionManifest = {
   description: 'Adds Reroll/Continue and User Impersonate buttons to the chat options menu.',
   version: '1.0.0',
   author: 'NeoTavern Team',
+  icon: 'fa-solid fa-arrow-right'
 };

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -13,6 +13,7 @@ export interface ExtensionManifest {
   js?: string;
   css?: string;
   auto_update?: boolean;
+  icon?: string;
 }
 
 export interface ExtensionPrompt {


### PR DESCRIPTION
Added optional extension icons to `ExtensionManifest`.
```javascript
import type { ExtensionManifest } from '../../../types';

export const manifest: ExtensionManifest = {
  name: 'core.chat-translation',
  display_name: 'Chat Translation',
  description: 'Translate chat messages using an LLM connection profile.',
  version: '1.0.0',
  author: 'NeoTavern Team',
  icon: 'fa-solid fa-language'
};
```