### PR TITLE
Ctrl+Z extension.

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1186,6 +1186,27 @@
       "branchCreationFailed": "Failed to create branch",
       "branchName": "Branch",
       "loadChatFailed": "Failed to load selected chat"
+    },
+    "undo": {
+      "discardLabel": "Discard saves.",
+      "discardTitle": "Discard all chats from the undo history.",
+      "redoLabel": "Redo.",
+      "redoTitle": "Redo the last chat change.",
+      "saveLabel": "Save.",
+      "saveTitle": "Save the current chat to undo history.",
+      "settings": {
+        "chatLengthWarning": "⚠️ Warning: Increasing Max Chat Length can significantly impact performance on very large chats.",
+        "enableCtrlZ": "Enable the Ctrl+Z/Ctrl+Shift+Z hotkeys",
+        "maxChatLength": "Max Chat Length.",
+        "maxUndoSnapshots": "Max Undo Snapshots.",
+        "showSaveButtons": "Show Save/Reset in ☰",
+        "showToasts": "Show toasts on Undo/Redo.",
+        "showUndoButtons": "Show Undo/Redo in ☰",
+        "snapshotEvents": "Toggle snapshot events (Advanced)",
+        "snapshotEventsDescription": "These events will determine which actions are saved to your \"undo history\"."
+      },
+      "undoLabel": "Undo.",
+      "undoTitle": "Undo the last chat change."
     }
   },
   "persona": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@intlify/unplugin-vue-i18n": "^11.0.1",
     "bowser": "^2.12.1",
     "codemirror": "^6.0.2",
+    "deep-object-diff": "^1.1.9",
     "dompurify": "^3.3.0",
     "handlebars": "^4.7.8",
     "localforage": "^1.10.0",

--- a/src/extensions/built-in/undo/SettingsPanel.vue
+++ b/src/extensions/built-in/undo/SettingsPanel.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import { CollapsibleSection, FormItem, RangeControl, Toggle } from '../../../components/UI';
+import { useStrictI18n } from '../../../composables/useStrictI18n';
+import type { ExtensionAPI } from '../../../types';
+import { DEFAULT_SETTINGS, type ExtensionSettings, type SettingChangeEvents } from './types.ts';
+
+const props = defineProps<{
+  api: ExtensionAPI<ExtensionSettings>;
+}>();
+
+const settings = ref<ExtensionSettings>(structuredClone(DEFAULT_SETTINGS));
+
+const { t } = useStrictI18n();
+
+onMounted(() => {
+  const saved = props.api.settings.get();
+  if (saved) {
+    settings.value = { ...settings.value, ...saved };
+  }
+});
+
+watch(
+  settings,
+  (newSettings) => {
+    console.log(newSettings);
+    props.api.settings.set(undefined, newSettings);
+    props.api.settings.save();
+  },
+  { deep: true },
+);
+
+//All setting changes will emit an event.
+function emitSettingChanged<K extends keyof ExtensionSettings>(setting: K, value: ExtensionSettings[K]) {
+  props.api.events.emit(`undo:setting:${setting}` as keyof SettingChangeEvents, value);
+}
+</script>
+
+<template>
+  <div class="undo-settings">
+    {{ t('extensionsBuiltin.undo.settings.chatLengthWarning') }}
+    <li v-for="(value, setting) in settings" :key="setting">
+      <div v-if="typeof value == 'boolean'">
+        {{ t(`extensionsBuiltin.undo.settings.${setting}` as any) }}
+        <Toggle
+          v-model="settings[setting] as boolean"
+          :title="t(`extensionsBuiltin.undo.settings.${setting}` as any)"
+          @change="emitSettingChanged(setting, value)"
+        />
+      </div>
+
+      <RangeControl
+        v-else-if="typeof(value)=='number'"
+        v-model="settings[setting] as number"
+        :label="t(`extensionsBuiltin.undo.settings.${setting}` as any)"
+        :min="0"
+        :step="10"
+        :max="10000"
+        @change="emitSettingChanged(setting, value)"
+      />
+    </li>
+
+    <CollapsibleSection :title="t('extensionsBuiltin.undo.settings.snapshotEvents')" :is-open="false">
+      {{ t('extensionsBuiltin.undo.settings.snapshotEventsDescription') }}
+      <li v-for="(value, snapshotEvent) in settings.snapshotEvents" :key="snapshotEvent as string">
+        <FormItem :label="snapshotEvent">
+          <Toggle
+            v-if="typeof(value) == 'boolean'"
+            v-model="settings.snapshotEvents[snapshotEvent] as boolean"
+            @change="emitSettingChanged(snapshotEvent as any, value)"
+          />
+        </FormItem>
+      </li>
+    </CollapsibleSection>
+  </div>
+</template>

--- a/src/extensions/built-in/undo/applyDelta.ts
+++ b/src/extensions/built-in/undo/applyDelta.ts
@@ -1,0 +1,37 @@
+// https://github.com/transformation-dev/blueprint/blob/master/packages/cloudflare-do-utils/src/apply-delta.js
+// Originally written by Larry Maccherone.
+
+/* eslint-disable no-param-reassign */
+function innerApplyDelta(obj: object, delta: object) {
+  const keys = Object.keys(delta);
+  for (let i = keys.length - 1; i >= 0; i--) {
+    const key = keys[i];
+
+    //Prevent Prototype pollution. https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Prototype_pollution
+    if (key === 'prototype' || key === '__proto__' || key === 'constructor') continue;
+
+    if (Array.isArray(delta[key]) || delta[key] instanceof Set || delta[key] instanceof Map) {
+      obj[key] = delta[key];
+    } else if (delta[key] === undefined) {
+      if (Array.isArray(obj)) {
+        obj.splice(Number(key), 1);
+      } else {
+        delete obj[key];
+      }
+    } else if (typeof delta[key] === 'object' && delta[key] !== null) {
+      obj[key] = innerApplyDelta(obj[key] ?? {}, delta[key]);
+    } else {
+      obj[key] = delta[key];
+    }
+  }
+  return obj;
+}
+
+/**
+ * This function is only intended for use in ChatHistory until it gets fixed upstream.
+ * applyDelta has known issues, Don't use it.
+ * https://github.com/SillyTavern/SillyTavern/pull/4819#discussion_r2595634539
+ */
+export function applyDelta(obj: object, delta: object) {
+  return innerApplyDelta(obj, delta);
+}

--- a/src/extensions/built-in/undo/index.ts
+++ b/src/extensions/built-in/undo/index.ts
@@ -1,0 +1,287 @@
+import { diff } from 'deep-object-diff';
+import { isEqual } from 'lodash-es';
+import { nextTick } from 'vue';
+import { toast } from '../../../composables/useToast.ts';
+import type { ChatMessage } from '../../../public-api.ts';
+import type { ExtensionAPI } from '../../../types';
+import { deepClone } from '../../../utils/extensions.ts';
+import { applyDelta } from './applyDelta.ts'; //applyDelta is not typed.
+import { toastTimeout, type ExtensionSettings } from './types.ts';
+
+import { manifest } from './manifest.ts';
+import { setup } from './ui.ts';
+export { manifest };
+export function activate(api: ExtensionAPI<ExtensionSettings>) {
+  //Setup is in ui.ts
+  return setup(api);
+}
+
+export class ChatHistory {
+  chatData: ChatMessage[];
+  chatHistory: ChatMessage[][] | object[];
+  chatHistoryIndex: number;
+  indexChat: () => ChatMessage[];
+  settings: ExtensionSettings;
+  api: ExtensionAPI<ExtensionSettings>;
+
+  /**
+   * ChatHistory is meant to store an undo history, it's inefficient for most other purposes.
+   * A read or write to the chatHistory scales at O(n) where n="distance from chatHistoryIndex".
+   * Here, the offset is always 1.
+   * During normal usage, The memory use of chatHistory will be 2*chat, regardless of how many undo history entries are stored.
+   * In comparison, storing full copies of the chat would require much higher memory usage (historyLength*chat), but would scale at O(1).
+   * Much lower memory use is easily worth the slightly higher read/write time.
+   * @param {ChatMessage[]} chatData or ChatTree.
+   */
+  constructor(chatData: ChatMessage[], settings: ExtensionSettings, api: ExtensionAPI<ExtensionSettings>) {
+    //chatTree or chat.
+    this.chatData = chatData;
+    /** @type {ChatMessage[][]|object[]} Only the chat at indexChat is a chatMessage[], the rest are diffs. */
+    this.chatHistory = [];
+    /** This should only be set by stepIndex. */
+    this.chatHistoryIndex = 0;
+    /** @type {() => ChatMessage[]} Chat, or chatTree at the current Index */
+    this.indexChat = () => {
+      return this.chatHistory[this.chatHistoryIndex] as ChatMessage[];
+    };
+    this.settings = settings;
+    this.api = api;
+  }
+  /**
+   * Regenerates the full chat of an adjacent diff.
+   * @param {-1|1} offset index -1 or +1.
+   * @param {object} [fullChat=this.indexChat()] this.indexChat() by default.
+   * @param {number} [fullChatIndex=this.indexChat()] The id of fullChat, chatHistoryIndex by default.
+   * @returns {object} The full chat at the offset, or nothing.
+   */
+  adjacentChat(offset = 1, fullChat = this.indexChat(), fullChatIndex = this.chatHistoryIndex) {
+    const offsetId = fullChatIndex + offset;
+    const offsetChatDiff = this.chatHistory[offsetId];
+    if (typeof offsetChatDiff === 'object') {
+      return applyDelta(structuredClone(fullChat), structuredClone(offsetChatDiff)) as ChatMessage[];
+    }
+  }
+
+  /**
+   * Steps, moving chatHistoryIndex. forwards or backwards.
+   * In chatHistory, the chat at chatHistoryIndex is the only full copy.
+   * When chatHistoryIndex moves, the adjacent diffs are recreated on the new index.
+   * Returns the chat at offset, if it exists.
+   * @param {-1|1} offset index -1 or +1.
+   * @param {ChatMessage[]} newChatData This defaults to the chat at offset.
+   * @returns {object} The new chat at offset.
+   */
+  stepIndex(offset = 1, newChatData: ChatMessage[] | undefined = undefined) {
+    //The next chat over must also be updated, it's based on the chat that's about to be written.
+    const nextChat = this.adjacentChat(offset);
+    newChatData ??= nextChat;
+    if (typeof newChatData !== 'object') {
+      //The diffs cannot be based upon nothing.
+      throw new Error(
+        `Cannot step! Offset ${offset} from ${this.chatHistoryIndex} cannot be updated if the newChatData doesn't exist.`,
+      );
+    }
+
+    //The current indexChat will be replaced with it's diff.
+    const currentChat = this.indexChat();
+    const currentChatDiff = diff(newChatData, currentChat);
+
+    this.chatHistory[this.chatHistoryIndex] = currentChatDiff;
+
+    //This shifts the relative positions. e.g., nextChat is now indexChat, currentChat is now the previous chat..
+    this.chatHistoryIndex += offset;
+
+    //If the nextChat (now indexChat) as changed, then it's adjacentChat must be updated.
+    if (typeof nextChat !== 'undefined' && !(nextChat === newChatData)) {
+      //If the offset diff does not exist, this will do nothing.
+      this.updateOffset(newChatData, offset, nextChat);
+    }
+    //Write the newChatData, both diffs are based upon this.
+    this.chatHistory[this.chatHistoryIndex] = newChatData;
+    return newChatData;
+  }
+
+  /**
+   * Updates the previous or next chat with the newChatData, if it exists.
+   * This does not update chatHistoryIndex or the indexChat.
+   * Using this function without updating indexChat leaves the offsetChat ungettable.
+   * @param {object} newChatData The offset diffs will be created against newChatData.
+   * @param {-1|1} offset index -1 or +1.
+   * @param {object} fullChat The full chat that the diff was originally created from.
+   * @returns {object} The full chat at the offset, or nothing.
+   */
+  updateOffset(newChatData: ChatMessage[], offset = 1, fullChat = this.indexChat()) {
+    if (typeof fullChat !== 'object') {
+      throw new Error(
+        `The chat offset ${offset} from ${this.chatHistoryIndex} cannot be updated if the fullChat it was created with does not exist.`,
+      );
+    }
+
+    //Create the offsetChat from by updating the fullChat with the diff.
+    const offsetChat = this.adjacentChat(offset, fullChat);
+    if (typeof offsetChat === 'object') {
+      //Create a diff from the newChatData and offsetChat, overwrite the old diff.
+      const updatedPreviousDiff = structuredClone(diff(newChatData, offsetChat));
+      this.chatHistory[this.chatHistoryIndex - offset] = updatedPreviousDiff;
+      return offsetChat;
+    }
+  }
+
+  /**
+   * Resets chatHistory, and set's the first entry.
+   * @param {boolean} showToast toast that the has been cleared.
+   */
+  async resetChatSnapshots(showToast = true) {
+    this.chatHistory.length = 0;
+    this.chatHistoryIndex = 0;
+
+    this.chatHistory = [deepClone(this.chatData)];
+    if (showToast)
+      toast.warning(`You now have ${this.chatHistory.length} snapshots.`, `Success.`, {
+        timeout: toastTimeout,
+        preventDuplicates: true,
+      });
+  }
+
+  /**
+   * Save a copy of chatData to chatHistory to chatHistoryIndex + 1.
+   * @param {boolean} showToast toast that the chat has saved.
+   */
+  async saveChatSnapshot(showToast = false) {
+    const t1 = performance.now();
+    const maxUndoSnapshots = this.settings.maxUndoSnapshots;
+    const maxChatLength = this.settings.maxChatLength;
+
+    //Enforce the maximum chat length.
+    if (Array.isArray(this.chatData) && this.chatData.length > maxChatLength) {
+      if (showToast)
+        toast.error(
+          `It's in 'Extensions > Chat Undo History > Max chat length'`,
+          `You cannot save the chat because it's ${this.chatData.length - maxChatLength} messages longer than your max chat length limit (${maxChatLength}). (Check Settings.)`,
+          { timeout: toastTimeout, preventDuplicates: true },
+        );
+      return;
+    }
+
+    //Max history cannot be less than zero.
+    if (0 >= maxUndoSnapshots) {
+      if (showToast)
+        toast.error(
+          `It's in 'Extensions > Chat Undo History > Max Undo Snapshots'`,
+          `You cannot save the chat because your Max Undo Snapshots is set to ${maxUndoSnapshots}. (Check Settings.)`,
+          { timeout: toastTimeout, preventDuplicates: true },
+        );
+      return;
+    }
+
+    //Currently a full chat.
+    const previousChat = this.indexChat();
+
+    //Only save changed chats.
+    if (isEqual(deepClone(this.chatData), previousChat)) {
+      if (showToast)
+        toast.warning(`The chat is unchanged. You still have ${this.chatHistory.length} snapshots.`, `Warning.`, {
+          timeout: toastTimeout,
+          preventDuplicates: true,
+        });
+      return;
+    }
+
+    //Overwrite history that has been undone.
+    //e.g. If you undo, then start typing, you cannot redo.
+    this.chatHistory.splice(this.chatHistoryIndex + 1);
+
+    //Enforce maxChatHistory.
+    this.chatHistory.splice(0, this.chatHistory.length - maxUndoSnapshots);
+
+    //Save the full history.
+    const currentChat = deepClone(this.chatData);
+    //Save the chat, and replace the previous chat with a diff.
+    this.stepIndex(1, currentChat);
+
+    if (showToast)
+      toast.success(`You now have ${this.chatHistory.length} snapshots.`, `Success.`, {
+        timeout: toastTimeout,
+        preventDuplicates: true,
+      });
+    console.debug(`Saved a chat snapshot in ${(performance.now() - t1) / 1000} seconds.`);
+  }
+
+  /**
+   * Load the previous or next snapshot.
+   * @param {-1|1} offset index -1 or +1.
+   * @returns
+   */
+  async loadChatSnapshot(offset: -1 | 1) {
+    const t1 = performance.now();
+    const showUndoToast = this.settings.showToasts;
+    const index = this.chatHistoryIndex + offset;
+    const maximumChatLength = this.settings.maxChatLength;
+
+    //Don't overwrite chats that are longer than maximumChatLength.
+    if (this.chatData.length > maximumChatLength) {
+      toast.error(
+        `It's in 'Extensions > Chat Undo History > Max chat length'`,
+        `You cannot load the chat because it's ${this.chatData.length - maximumChatLength} messages longer than your max chat length limit (${maximumChatLength}). (Check Settings.)`,
+        { timeout: toastTimeout, preventDuplicates: true },
+      );
+      return;
+    }
+
+    if (typeof this.chatHistory[index] !== 'undefined') {
+      //The created/updated/deleted messages will need to be guessed.
+      const createdIds: Array<number> = [];
+      const updatedIds: Array<number> = [];
+      const deletedIds: Array<number> = [];
+      const newDiff = this.chatHistory[this.chatHistoryIndex + offset];
+
+      const newChat = this.stepIndex(offset);
+      const oldChatLength = this.chatData.length;
+
+      //Replace the chat.
+      this.chatData.splice(0, oldChatLength, ...newChat);
+
+      //Store the new messages.
+      Object.entries(newDiff).forEach(async ([id, messageDiff]) => {
+        const messageId = Number(id);
+        if (!this.chatData[messageId] && typeof messageDiff === 'undefined') deletedIds.push(messageId);
+        if (!this.chatData[messageId] && typeof messageDiff === 'object') createdIds.push(messageId);
+        if (this.chatData[messageId] && typeof messageDiff === 'object') updatedIds.push(messageId);
+      });
+
+      await this.api.events.emit('undo:snapshot-loaded', index);
+
+      //Emit events
+      createdIds.forEach(async (id) => {
+        await this.api.events.emit('message:created', this.chatData[id]);
+      });
+      updatedIds.forEach(async (id) => {
+        await this.api.events.emit('message:updated', id, this.chatData[id]);
+      });
+      if (deletedIds.length > 0) {
+        await this.api.events.emit('message:deleted', deletedIds);
+      }
+
+      await nextTick();
+      if (showUndoToast)
+        toast.success(`Snapshot ${this.chatHistoryIndex + 1}/${this.chatHistory.length} has been loaded.`, `Success.`, {
+          timeout: toastTimeout,
+          preventDuplicates: true,
+        });
+    } else {
+      if (showUndoToast)
+        toast.error(
+          `Snapshot ${index + 1}/${this.chatHistory.length} does not exist!`,
+          `The snapshot cannot be loaded.`,
+          { timeout: toastTimeout, preventDuplicates: true },
+        );
+    }
+    console.debug(`Loaded a chat snapshot in ${(performance.now() - t1) / 1000} seconds.`);
+  }
+  async loadPreviousSnapshot() {
+    await this.loadChatSnapshot(-1);
+  }
+  async loadNextSnapshot() {
+    await this.loadChatSnapshot(1);
+  }
+}

--- a/src/extensions/built-in/undo/manifest.ts
+++ b/src/extensions/built-in/undo/manifest.ts
@@ -1,0 +1,9 @@
+import type { ExtensionManifest } from '../../../types';
+
+export const manifest: ExtensionManifest = {
+  name: 'core.undo',
+  display_name: 'Chat Undo History (Ctrl+Z)',
+  description: 'Adds Chat Undo History (Ctrl+Z) and undo buttons to the chat options menu.',
+  version: '0.0.1',
+  icon: 'fa-solid fa-clock-rotate-left',
+};

--- a/src/extensions/built-in/undo/types.ts
+++ b/src/extensions/built-in/undo/types.ts
@@ -1,0 +1,54 @@
+import { DebounceTimeout } from '../../../public-api';
+import type { ExtensionEventMap } from '../../../types';
+
+export const extensionName = 'undo';
+export const toastTimeout = 400;
+
+//Debounce duration.
+//Needed to prevent redundant saves. https://github.com/SillyTavern/SillyTavern/pull/4819#discussion_r2571515880
+export const saveDebounceDuration = DebounceTimeout.SHORT;
+
+export interface ExtensionSettings {
+  showUndoButtons: boolean;
+  showSaveButtons: boolean;
+  maxChatLength: number;
+  maxUndoSnapshots: number;
+  showToasts: boolean;
+  enableCtrlZ: boolean;
+  snapshotEvents: Partial<Record<keyof ExtensionEventMap, boolean>>;
+}
+
+//All setting changes will emit an event.
+export type SettingChangeEvents = {
+  [K in keyof ExtensionSettings as `undo:setting:${K}`]: [ExtensionSettings[K]];
+};
+
+declare module '../../../types' {
+  export interface ExtensionEventMap extends SettingChangeEvents {
+    'undo:snapshot-loaded': [number];
+    'undo:snapshot-saved': [number];
+  }
+}
+//Snapshot the chat when a message is modified.
+export const snapshotEvents = [
+  'message:created', // event_types.MESSAGE_SENT, event_types.MESSAGE_RECEIVED,
+  'message:updated', // event_types.MESSAGE_EDITED, event_types.MESSAGE_UPDATED
+  'message:deleted', // event_types.MESSAGE_DELETED,
+  //There's no equivalent for these events:
+  // event_types.MESSAGE_SWIPE_ENDED,
+  // event_types.MESSAGE_FILE_EMBEDDED,
+  // event_types.MESSAGE_REASONING_EDITED,
+  // event_types.MESSAGE_REASONING_DELETED,
+  'message:swipe-deleted', // event_types.MESSAGE_SWIPE_DELETED
+  //If an event without 'message:' in the name is added, some UI code must be changed.
+] as const;
+
+export const DEFAULT_SETTINGS: ExtensionSettings = {
+  showUndoButtons: true,
+  showSaveButtons: false,
+  maxChatLength: 500,
+  maxUndoSnapshots: 10000,
+  showToasts: true,
+  enableCtrlZ: false,
+  snapshotEvents: Object.fromEntries(snapshotEvents.map((event) => [event, true])),
+};

--- a/src/extensions/built-in/undo/ui.ts
+++ b/src/extensions/built-in/undo/ui.ts
@@ -1,0 +1,284 @@
+import debounce, { type DebouncedFunc } from 'lodash-es/debounce';
+import type { StrictT } from '../../../composables/useStrictI18n.ts';
+import i18n from '../../../i18n';
+import { useChatStore } from '../../../stores/chat.store.ts';
+import type { ExtensionAPI } from '../../../types';
+import { ChatHistory } from './index.ts';
+import SettingsPanel from './SettingsPanel.vue';
+import {
+  DEFAULT_SETTINGS,
+  saveDebounceDuration,
+  snapshotEvents,
+  type ExtensionSettings,
+  type SettingChangeEvents,
+} from './types.ts';
+
+// src/components/Popup/Popup.vue
+function isInput(event: KeyboardEvent) {
+  const target = event.target as HTMLElement;
+  return (
+    target.tagName === 'TEXTAREA' ||
+    target.tagName === 'INPUT' ||
+    target.isContentEditable ||
+    target.className.includes('cm-')
+  );
+}
+
+//Animate icon active.
+function setupActiveIndicator(unbinds: (() => void)[]) {
+  //Animate.
+  const animate = () => {
+    const icon = document.querySelector('[data-extension-id="core.undo"] .fa-solid') as HTMLElement;
+    if (icon) {
+      icon.style = 'animation: fa-spin 10s infinite linear reverse;';
+      unbinds.push(() => {
+        icon.style = '';
+      });
+    }
+  };
+  //Setup/cleanup.
+  const extensions = document.querySelector('.menu-button[title="Extensions"]');
+  if (extensions) {
+    extensions.addEventListener('click', animate);
+    unbinds.push(() => extensions.removeEventListener('click', animate));
+  }
+}
+
+//Binds/Unbinds Ctrl+Z on settings toggle.
+function setupUndoHotkey(
+  api: ExtensionAPI<ExtensionSettings>,
+  settings: ExtensionSettings,
+  chatHistory: ChatHistory,
+  unbinds: (() => void)[],
+) {
+  async function processUndoHotkey(event: KeyboardEvent) {
+    if (!isInput(event)) {
+      if ((event.ctrlKey || event.metaKey) && !event.altKey) {
+        //Undo.
+        if (event.key === 'z') await chatHistory.loadPreviousSnapshot();
+        //Redo.
+        if (event.key === 'Z') await chatHistory.loadNextSnapshot();
+      }
+    }
+  }
+
+  const toggleUndoHotkey = (enabled = true) => {
+    //Toggle on.
+    if (enabled) {
+      document.addEventListener('keydown', processUndoHotkey);
+    }
+    //Toggle off.
+    else {
+      document.removeEventListener('keydown', processUndoHotkey);
+    }
+  };
+  //If enabled, setup the hotkey.
+  toggleUndoHotkey(settings.enableCtrlZ);
+  //Disable the hotkey if the extension is disabled.
+  unbinds.push(() => toggleUndoHotkey(false));
+  //Listen for settings toggles.
+  unbinds.push(api.events.on('undo:setting:enableCtrlZ', toggleUndoHotkey));
+}
+
+//Setup snapshots on events.
+function setupSnapshotEvents(
+  api: ExtensionAPI<ExtensionSettings>,
+  settings: ExtensionSettings,
+  chatHistory: ChatHistory,
+  unbinds: (() => void)[],
+) {
+  const toggleEventFunction = (
+    event: keyof SettingChangeEvents,
+    enabled: boolean,
+    eventFunction: DebouncedFunc<() => Promise<void>>,
+  ) => {
+    //Toggle on.
+    if (enabled) {
+      api.events.on(event, eventFunction);
+    }
+    //Toggle off.
+    else {
+      api.events.off(event, eventFunction);
+    }
+  };
+
+  const saveChatSnapshotDebounced = debounce(() => chatHistory.saveChatSnapshot(false), saveDebounceDuration);
+  snapshotEvents.forEach((event) => {
+    //Initializes settings.
+    unbinds.push(
+      api.events.on(`undo:setting:${event}` as keyof SettingChangeEvents, (enabled) =>
+        toggleEventFunction(event as keyof SettingChangeEvents, enabled as boolean, saveChatSnapshotDebounced),
+      ),
+    );
+    //Don't enable disabled events.
+    if (settings.snapshotEvents[event]) unbinds.push(api.events.on(event, saveChatSnapshotDebounced));
+  });
+}
+
+function createButton(id: string, label: string, title: string, faIcon: string, onClick: () => void) {
+  const button = document.createElement('a');
+  button.id = id;
+  button.style.cursor = 'pointer';
+  button.className = 'options-menu-item';
+
+  const icon = document.createElement('i');
+  icon.className = `fa-solid ${faIcon}`;
+  button.title = label;
+
+  button.appendChild(icon);
+
+  const span = document.createElement('span');
+  span.textContent = title;
+  button.appendChild(span);
+
+  button.onclick = (e) => {
+    e.stopPropagation();
+    // document.body.click();
+    onClick();
+  };
+  return button;
+}
+
+function setupUndoRedoButtons(optionsMenu: Element, chatHistory: ChatHistory, t: StrictT) {
+  const undoButton = createButton(
+    'undo-options-menu-undo',
+    t('extensionsBuiltin.undo.undoTitle'),
+    t('extensionsBuiltin.undo.undoLabel'),
+    'fa-clock-rotate-left',
+    async () => await chatHistory.loadPreviousSnapshot(),
+  );
+  const redoButton = createButton(
+    'undo-options-menu-redo',
+    t('extensionsBuiltin.undo.redoTitle'),
+    t('extensionsBuiltin.undo.redoLabel'),
+    'fa-clock-rotate-left fa-flip-horizontal',
+    async () => await chatHistory.loadNextSnapshot(),
+  );
+
+  const undoRedo = document.createElement('a');
+  undoRedo.className = 'undo-options-menu-undo-redo';
+  undoRedo.style = 'display:flex';
+  undoRedo.appendChild(undoButton);
+  undoRedo.appendChild(redoButton);
+
+  optionsMenu.appendChild(undoRedo);
+  return () => undoRedo.remove();
+}
+
+function setupSaveDiscardButtons(optionsMenu: Element, chatHistory: ChatHistory, t: StrictT) {
+  const saveButton = createButton(
+    'undo-options-menu-save',
+    t('extensionsBuiltin.undo.saveTitle'),
+    t('extensionsBuiltin.undo.saveLabel'),
+    'fa-floppy-disk',
+    async () => await chatHistory.saveChatSnapshot(true),
+  );
+  const discardButton = createButton(
+    'undo-options-menu-discard',
+    t('extensionsBuiltin.undo.discardTitle'),
+    t('extensionsBuiltin.undo.discardLabel'),
+    'fa-trash-can',
+    async () => await chatHistory.resetChatSnapshots(true),
+  );
+
+  const saveDiscard = document.createElement('a');
+  saveDiscard.className = 'undo-options-menu-save-discard';
+  saveDiscard.style = 'display:flex';
+  saveDiscard.appendChild(saveButton);
+  saveDiscard.appendChild(discardButton);
+
+  optionsMenu.appendChild(saveDiscard);
+  return () => saveDiscard.remove();
+}
+
+let removeUndoRedo: ChildNode['remove'] | undefined;
+let removeSaveDiscard: ChildNode['remove'] | undefined;
+
+//Shows and hides the buttons on settings toggle.
+function refreshButtons(settings: ExtensionSettings, chatHistory: ChatHistory, unbinds: (() => void)[], t: StrictT) {
+  const optionsMenu = document.querySelector('.options-menu');
+
+  // If menu doesn't exist exist, skip
+  if (!optionsMenu) return;
+
+  // Undo/Redo buttons.
+  if (removeUndoRedo) removeUndoRedo();
+  if (settings.showUndoButtons) {
+    removeUndoRedo = setupUndoRedoButtons(optionsMenu, chatHistory, t);
+    unbinds.push(removeUndoRedo);
+  }
+
+  // Save/Discard buttons.
+  if (removeSaveDiscard) removeSaveDiscard();
+  if (settings.showSaveButtons) {
+    removeSaveDiscard = setupSaveDiscardButtons(optionsMenu, chatHistory, t);
+    unbinds.push(removeSaveDiscard);
+  }
+}
+
+export function setup(api: ExtensionAPI<ExtensionSettings>) {
+  // @ts-expect-error 'i18n.global' is of type 'unknown'
+  const t = i18n.global.t as StrictT;
+
+  // Prevents unused keys. These are used in settings.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  const _UsedI18nKeys = [
+    t('extensionsBuiltin.undo.settings.enableCtrlZ'),
+    t('extensionsBuiltin.undo.settings.maxChatLength'),
+    t('extensionsBuiltin.undo.settings.maxUndoSnapshots'),
+    t('extensionsBuiltin.undo.settings.showSaveButtons'),
+    t('extensionsBuiltin.undo.settings.showUndoButtons'),
+    t('extensionsBuiltin.undo.settings.showToasts'),
+  ];
+
+  let settingsApp: { unmount: () => void } | null = null;
+
+  const settingsContainer = document.getElementById(api.meta.containerId);
+  if (settingsContainer) {
+    settingsApp = api.ui.mount(settingsContainer, SettingsPanel, { api });
+  }
+
+  const unbinds: Array<() => void> = [];
+
+  const settings = api.settings.get() ?? DEFAULT_SETTINGS;
+
+  // Clear snapshot when changing chats
+  unbinds.push(
+    api.events.on('chat:entered', async () => {
+      const chatStore = useChatStore();
+      if (!chatStore.activeChat) return;
+
+      const chatHistory = new ChatHistory(chatStore.activeChat.messages, settings, api);
+      //Reset chatHistory to create the initial snapshot.
+      await chatHistory.resetChatSnapshots(false);
+      //When the extension is disabled, free memory.
+      unbinds.push(() => {
+        chatHistory.chatHistory = [];
+      });
+
+      //Binds/Unbinds Ctrl+Z on settings toggle.
+      setupUndoHotkey(api, settings, chatHistory, unbinds);
+
+      //Shows and hides the buttons on settings toggle.
+      const doRefreshButtons = () => refreshButtons(settings, chatHistory, unbinds, t);
+      doRefreshButtons();
+      unbinds.push(api.events.on('undo:setting:showUndoButtons', doRefreshButtons));
+      unbinds.push(api.events.on('undo:setting:showSaveButtons', doRefreshButtons));
+
+      //Animate icon when active.
+      setupActiveIndicator(unbinds);
+
+      //Setup snapshots on events.
+      setupSnapshotEvents(api, settings, chatHistory, unbinds);
+    }),
+  );
+  const deactivate = () => {
+    settingsApp?.unmount();
+    console.log('Undo Deactivated.', unbinds);
+    unbinds.forEach((u) => {
+      u();
+    });
+  };
+
+  return deactivate;
+}

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1190,6 +1190,27 @@ export interface MessageSchema {
       branchName: string;
       loadChatFailed: string;
     };
+    undo: {
+      discardLabel: string;
+      discardTitle: string;
+      redoLabel: string;
+      redoTitle: string;
+      saveLabel: string;
+      saveTitle: string;
+      settings: {
+        chatLengthWarning: string;
+        enableCtrlZ: string;
+        maxChatLength: string;
+        maxUndoSnapshots: string;
+        showSaveButtons: string;
+        showToasts: string;
+        showUndoButtons: string;
+        snapshotEvents: string;
+        snapshotEventsDescription: string;
+      };
+      undoLabel: string;
+      undoTitle: string;
+    };
   };
   persona: {
     createFromCharacter: {

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -158,7 +158,7 @@ export function unloadStyle(name: string) {
 
 // --- API Implementation ---
 
-function deepClone<T>(obj: T): T {
+export function deepClone<T>(obj: T): T {
   if (obj === null || obj === undefined) return obj;
   if (typeof obj !== 'object') return obj;
   return JSON.parse(JSON.stringify(obj)) as T;


### PR DESCRIPTION
I ported the [undo extension](https://github.com/SillyTavern/SillyTavern/pull/4819) from ST, I would appreciate a review of the code before I proceed.
This is the first time I've used Vue, Vite and Typescript so I've likely made many mistakes.

Questions:
- This extension requires `deep-object-diff`. May I include it in `packages.json` or a webpack/bundle?
- The `SettingsPanel` is created before `chat:entered` and some toggles need to call methods from `chatHistory`, which does not yet exist. To solve this I made [all settings emit events](https://github.com/NeoTavern/NeoTavern-Frontend/pull/75/changes#diff-f40f4cce06757e0ebaba2113443416268f73e44e77d2814c5f93ba424e157e95R35). This feels messy. Do you have another idea?
- Is there a better way to mark translations as "[used](https://github.com/NeoTavern/NeoTavern-Frontend/pull/75/changes)"? `manage-i18n.js` tried to remove them.
- May I leave [applyDelta](https://github.com/NeoTavern/NeoTavern-Frontend/pull/75/changes#diff-9310908077ac510443e4815480160c8cf2c1c51359a39e91cbcb38726205292cR5) untyped?
- Is the [undo:snapshot-loaded](https://github.com/NeoTavern/NeoTavern-Frontend/pull/75/changes) event okay?
- Can I prevent `node manage-i18n.js` from re-arranging `en.json` and `i18n.d.ts`? This commit is not 4000+ lines.

Known issues:

- [ ] The Undo/Redo and Save/Discard buttons apply to all chats, I'm not sure how to fix this cleanly.
- [ ] The message updated/created/deleted events are untested.
- [ ] The `SettingsPanel` may be cutoff on smaller screens.
- [ ] I haven't tested for bugs.