### PR TITLE
Clicking send on an empty message now generates a new response instead of sending a user message.

### DIFF
--- a/src/components/Chat/ChatInterface.vue
+++ b/src/components/Chat/ChatInterface.vue
@@ -48,7 +48,11 @@ const { floatingStyles: optionsMenuStyles } = useFloating(optionsButtonRef, opti
 });
 
 function submitMessage() {
-  if (!userInput.value.trim()) return;
+  //If userInput is empty, attempt to generate a new response.
+  if (!userInput.value.trim()) {
+    generate();
+    return;
+  };
   chatStore.sendMessage(userInput.value);
   userInput.value = '';
 


### PR DESCRIPTION
If send is pressed while the `userInput` is empty, attempt generate a new response instead of sending a user message.

```typescript

function submitMessage() {
  //If userInput is empty, attempt to generate a new response.
  if (!userInput.value.trim()) {
    generate();
    return;
  };
  chatStore.sendMessage(userInput.value);
  userInput.value = '';

  nextTick(() => {
    chatInput.value?.focus();
  });

  if (chatStore.activeChatFile) {
    promptStore.clearUserTyping(chatStore.activeChatFile);
  }
}
```