### PR TITLE
Adding option for character's picture to be used as chat's background

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1276,6 +1276,12 @@
           "chat": "Chat",
           "theme": "Theme"
         }
+      },
+      "background": {
+        "useCharacterAvatar": {
+          "label": "Use Character Avatar as Background",
+          "description": "Display the current character's avatar image as the chat background."
+        }
       }
     },
     "chat": {

--- a/src/services/settings-migration.service.ts
+++ b/src/services/settings-migration.service.ts
@@ -311,6 +311,7 @@ export function createDefaultSettings(): Settings {
         name: 'landscape autumn great tree.jpg',
         thumbnailColumns: 2,
         url: 'url("/backgrounds/landscape%20autumn%20great%20tree.jpg")',
+        useCharacterAvatar: false,
       },
       avatars: {
         neverResize: false,

--- a/src/settings-definition.ts
+++ b/src/settings-definition.ts
@@ -152,6 +152,15 @@ export const settingsDefinition: SettingDefinition[] = [
     widget: 'checkbox',
     defaultValue: false,
   },
+  {
+    id: 'ui.background.useCharacterAvatar',
+    label: 'settings.ui.background.useCharacterAvatar.label',
+    description: 'settings.ui.background.useCharacterAvatar.description',
+    category: 'UI & Display',
+    type: 'boolean',
+    widget: 'checkbox',
+    defaultValue: false,
+  },
 
   // --- Appearance ---
   {

--- a/src/stores/background.store.ts
+++ b/src/stores/background.store.ts
@@ -4,6 +4,7 @@ import { deleteBackground, fetchAllBackgrounds, renameBackground, uploadBackgrou
 import { useStrictI18n } from '../composables/useStrictI18n';
 import { toast } from '../composables/useToast';
 import type { BackgroundFitting } from '../types';
+import { useCharacterStore } from './character.store';
 import { useChatStore } from './chat.store';
 import { useSettingsStore } from './settings.store';
 
@@ -11,6 +12,7 @@ export const useBackgroundStore = defineStore('background', () => {
   const { t } = useStrictI18n();
   const settingsStore = useSettingsStore();
   const chatStore = useChatStore();
+  const characterStore = useCharacterStore();
 
   const systemBackgrounds = ref<string[]>([]);
   const chatBackgrounds = ref<string[]>([]);
@@ -31,6 +33,14 @@ export const useBackgroundStore = defineStore('background', () => {
   });
 
   const currentBackgroundUrl = computed(() => {
+    // Check if character avatar background is enabled
+    if (settingsStore.settings.ui.background.useCharacterAvatar) {
+      const activeCharacter = characterStore.activeCharacters[0];
+      if (activeCharacter?.avatar) {
+        return `url("/characters/${encodeURIComponent(activeCharacter.avatar)}")`;
+      }
+    }
+
     const lockedBg = chatStore.activeChat?.metadata.custom_background;
     return lockedBg ?? settingsStore.settings.ui.background.url;
   });

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -351,6 +351,7 @@ export interface Settings {
       url: string;
       fitting: BackgroundFitting;
       thumbnailColumns: number;
+      useCharacterAvatar: boolean;
     };
     avatars: {
       neverResize: boolean;


### PR DESCRIPTION
Hello!

Firstly, I would like to say thank you for the work your putting into this project. I've been using it nearly fully compared to sillytavern since your last reddit post.

Secondly, this was a way to test Google Antigravity and add a very little feature I've been wanting on sillytavern for a while now. I added a way to use the character's card picture as the background picture. I personally use it as a way to keep a reference for my imagination while I imagine what is depicted textually during chats.

For the sake of transparency, I did not write a single line of code of this commit, but I did search for the right files first to understand where is the background feature, then read the generated content. The "lint" and "format" were run and I even ran tests, even though it probably wasn't necessary, but just to make sure.

What do you think of this implementation?