### PR TITLE
perf: use cloneDeep instead of stringify

### DIFF
--- a/src/api/generation.ts
+++ b/src/api/generation.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash-es';
 import { aiConfigDefinition } from '../ai-config-definition';
 import { CustomPromptPostProcessing } from '../constants';
 import { ToolService } from '../services/tool.service';
@@ -689,7 +690,7 @@ class ToolCallAccumulator {
    * @returns A fresh array of the complete tool calls.
    */
   public getCalls(): ApiChatToolCall[] {
-    return JSON.parse(JSON.stringify(this.tools));
+    return cloneDeep(this.tools);
   }
 }
 

--- a/src/components/NavBar/ApiConnectionsDrawer.vue
+++ b/src/components/NavBar/ApiConnectionsDrawer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { cloneDeep } from 'lodash-es';
 import { computed, ref } from 'vue';
 import { apiConnectionDefinition } from '../../api-connection-definition';
 import { buildChatCompletionPayload, ChatCompletionService } from '../../api/generation';
@@ -188,7 +189,7 @@ async function testMessage() {
       model: apiStore.activeModel || '',
       provider: settingsStore.settings.api.provider,
       samplerSettings: {
-        ...JSON.parse(JSON.stringify(settingsStore.settings.api.samplers)),
+        ...cloneDeep(settingsStore.settings.api.samplers),
         max_tokens: 50,
         max_context: 200,
         stream: false,

--- a/src/components/NavBar/InstructTemplatePopup.vue
+++ b/src/components/NavBar/InstructTemplatePopup.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { cloneDeep } from 'lodash-es';
 import { ref, watch } from 'vue';
 import { useStrictI18n } from '../../composables/useStrictI18n';
 import { useApiStore } from '../../stores/api.store';
@@ -30,7 +31,7 @@ watch(
       if (props.templateId) {
         const found = apiStore.instructTemplates.find((t) => t.id === props.templateId || t.name === props.templateId);
         if (found) {
-          activeTemplate.value = JSON.parse(JSON.stringify(found));
+          activeTemplate.value = cloneDeep(found);
         }
       } else {
         activeTemplate.value = createDefaultInstructTemplate();

--- a/src/components/NavBar/UserSettingsDrawer.vue
+++ b/src/components/NavBar/UserSettingsDrawer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { cloneDeep } from 'lodash-es';
 import { computed, ref } from 'vue';
 import { Checkbox, CollapsibleSection, FormItem, Input, RangeControl, Search, Select } from '../../components/UI';
 import { useMobile } from '../../composables/useMobile';
@@ -15,7 +16,7 @@ const searchTerm = ref('');
 const { isDeviceMobile } = useMobile();
 
 const filteredDefinitions = computed(() => {
-  let deepCopy = JSON.parse(JSON.stringify(settingsStore.definitions)) as SettingDefinition[];
+  let deepCopy = cloneDeep(settingsStore.definitions) as SettingDefinition[];
   deepCopy.filter((def) => {
     if (def.showOn === 'mobileDevice') {
       return isDeviceMobile.value;

--- a/src/composables/useChatGeneration.ts
+++ b/src/composables/useChatGeneration.ts
@@ -1,4 +1,4 @@
-import { escapeRegExp } from 'lodash-es';
+import { cloneDeep, escapeRegExp } from 'lodash-es';
 import { computed, nextTick, ref, type Ref } from 'vue';
 import {
   buildChatCompletionPayload,
@@ -430,7 +430,7 @@ export function useChatGeneration(deps: ChatGenerationDependencies) {
     const tokenizer = new ApiTokenizer({ tokenizerType: settings.api.tokenizer, model: effectiveModel });
 
     // Event-driven Context Resolution
-    const contextCharactersWrapper = { characters: [JSON.parse(JSON.stringify(activeCharacter))] as Character[] };
+    const contextCharactersWrapper = { characters: [cloneDeep(activeCharacter)] as Character[] };
     await eventEmitter.emit('generation:resolve-context', contextCharactersWrapper, { generationId });
     const charactersForContext = contextCharactersWrapper.characters;
 

--- a/src/extensions/built-in/mythic-agents/SettingsPanel.vue
+++ b/src/extensions/built-in/mythic-agents/SettingsPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Expression } from 'jsep';
 import jsep from 'jsep';
+import { cloneDeep } from 'lodash-es';
 import { computed, onMounted, ref, watch } from 'vue';
 import { ConnectionProfileSelector } from '../../../components/common';
 import type { CustomAction } from '../../../components/common/PresetControl.vue';
@@ -26,7 +27,7 @@ const props = defineProps<{
 
 const initial: MythicSettings = { ...DEFAULT_BASE_SETTINGS };
 
-const settings = ref<MythicSettings>(JSON.parse(JSON.stringify(initial)));
+const settings = ref<MythicSettings>(cloneDeep(initial));
 const popupStore = usePopupStore();
 const activeTab = ref('general');
 const activePromptTab = ref('initialScene');
@@ -350,9 +351,9 @@ async function handleCreatePreset() {
     const newPreset: MythicPreset = {
       name: presetName,
       data: {
-        fateChart: JSON.parse(JSON.stringify(currentPreset.value.data.fateChart)),
-        eventGeneration: JSON.parse(JSON.stringify(currentPreset.value.data.eventGeneration)),
-        une: JSON.parse(JSON.stringify(currentPreset.value.data.une)),
+        fateChart: cloneDeep(currentPreset.value.data.fateChart),
+        eventGeneration: cloneDeep(currentPreset.value.data.eventGeneration),
+        une: cloneDeep(currentPreset.value.data.une),
         characterTypes: [...currentPreset.value.data.characterTypes],
       },
     };
@@ -488,7 +489,7 @@ async function handleResetAllPresets() {
     cancelButton: true,
   });
   if (confirm) {
-    settings.value.presets = JSON.parse(JSON.stringify(initial.presets));
+    settings.value.presets = cloneDeep(initial.presets);
     selectedPreset.value = 'Default';
     settings.value.selectedPreset = 'Default';
     loadJsonFromSettings();

--- a/src/extensions/built-in/rewrite/SettingsPanel.vue
+++ b/src/extensions/built-in/rewrite/SettingsPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { cloneDeep } from 'lodash-es';
 import { computed, onMounted, ref, watch } from 'vue';
 import { ConnectionProfileSelector, SplitPane } from '../../../components/common';
 import { Button, Checkbox, FormItem, Input, Select, Textarea } from '../../../components/UI';
@@ -77,7 +78,7 @@ function duplicateTemplate(id: string) {
     ...original,
     id: uuidv4(),
     name: `${original.name} (Copy)`,
-    args: original.args ? JSON.parse(JSON.stringify(original.args)) : [],
+    args: original.args ? cloneDeep(original.args) : [],
   };
   settings.value.templates.push(newTemplate);
   editingTemplateId.value = newTemplate.id;
@@ -128,7 +129,7 @@ async function resetTemplates() {
       if (isDefaultTemplate(template.id)) {
         const defaultTemplate = DEFAULT_TEMPLATES.find((dt) => dt.id === template.id);
         if (defaultTemplate) {
-          const resetTemplate = JSON.parse(JSON.stringify(defaultTemplate));
+          const resetTemplate = cloneDeep(defaultTemplate);
           resetTemplate.id = template.id;
           Object.assign(template, resetTemplate);
         }
@@ -138,7 +139,7 @@ async function resetTemplates() {
     DEFAULT_TEMPLATES.forEach((defaultTemplate) => {
       const exists = settings.value.templates.some((t) => t.id === defaultTemplate.id);
       if (!exists) {
-        const newTemplate = JSON.parse(JSON.stringify(defaultTemplate));
+        const newTemplate = cloneDeep(defaultTemplate);
         settings.value.templates.push(newTemplate);
       }
     });

--- a/src/extensions/built-in/tracker/SettingsPanel.vue
+++ b/src/extensions/built-in/tracker/SettingsPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { cloneDeep } from 'lodash-es';
 import { computed, onMounted, ref, watch } from 'vue';
 import { ConnectionProfileSelector, PresetControl } from '../../../components/common';
 import { Button, FormItem, Input, Select, Textarea, Toggle } from '../../../components/UI';
@@ -84,8 +85,8 @@ async function handlePresetCreate() {
       return;
     }
     const newPreset: TrackerSchemaPreset = activePreset.value
-      ? JSON.parse(JSON.stringify(activePreset.value)) // Deep copy current
-      : JSON.parse(JSON.stringify(DEFAULT_PRESETS[0])); // Or copy default
+      ? cloneDeep(activePreset.value) // Deep copy current
+      : cloneDeep(DEFAULT_PRESETS[0]); // Or copy default
 
     newPreset.name = value;
     settings.value.schemaPresets.push(newPreset);
@@ -153,7 +154,7 @@ async function handleResetAll() {
   });
 
   if (result === POPUP_RESULT.AFFIRMATIVE) {
-    settings.value.schemaPresets = JSON.parse(JSON.stringify(DEFAULT_PRESETS));
+    settings.value.schemaPresets = cloneDeep(DEFAULT_PRESETS);
     settings.value.activeSchemaPresetName = DEFAULT_PRESETS[0].name;
     props.api.ui.showToast('Tracker presets have been reset.', 'success');
   }

--- a/src/stores/persona.store.ts
+++ b/src/stores/persona.store.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash-es';
 import { defineStore } from 'pinia';
 import { computed, nextTick, ref, toRaw } from 'vue';
 import {
@@ -216,7 +217,7 @@ export const usePersonaStore = defineStore('persona', () => {
       await uploadPersonaAvatar(newAvatarId, file);
 
       const newPersona: Persona = {
-        ...JSON.parse(JSON.stringify(persona)),
+        ...cloneDeep(persona),
         avatarId: newAvatarId,
         name: newName,
       };

--- a/src/stores/prompt.store.ts
+++ b/src/stores/prompt.store.ts
@@ -1,4 +1,5 @@
 import localforage from 'localforage';
+import { cloneDeep } from 'lodash-es';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import type { ExtensionPrompt, ItemizedPrompt } from '../types';
@@ -15,7 +16,7 @@ export const usePromptStore = defineStore('prompt', () => {
       if (!chatId) {
         return;
       }
-      await promptStorage.setItem(chatId, JSON.parse(JSON.stringify(itemizedPrompts.value)));
+      await promptStorage.setItem(chatId, cloneDeep(itemizedPrompts.value));
     } catch {
       console.log('Error saving itemized prompts for chat', chatId);
     }

--- a/src/stores/world-info.store.ts
+++ b/src/stores/world-info.store.ts
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash-es';
+import { cloneDeep, debounce } from 'lodash-es';
 import { defineStore } from 'pinia';
 import { computed, nextTick, ref } from 'vue';
 import * as api from '../api/world-info';
@@ -85,7 +85,7 @@ export const useWorldInfoStore = defineStore('world-info', () => {
     if (book) {
       try {
         await api.saveWorldInfoBook(book.name, book);
-        worldInfoCache.value[book.name] = JSON.parse(JSON.stringify(book));
+        worldInfoCache.value[book.name] = cloneDeep(book);
         await nextTick();
         await eventEmitter.emit('world-info:book-updated', book);
       } catch (error) {
@@ -197,7 +197,7 @@ export const useWorldInfoStore = defineStore('world-info', () => {
     const book = worldInfoCache.value[filename];
     if (!book) return;
 
-    const entryToCopy = JSON.parse(JSON.stringify(entry));
+    const entryToCopy = cloneDeep(entry);
     const newEntry = {
       ...entryToCopy,
       uid: getNewUid(book),

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -85,6 +85,7 @@ export async function countTokens(
 
 // --- Event Emitter ---
 
+import { cloneDeep } from 'lodash-es';
 import { getModelCapabilities } from '../api/provider-definitions';
 import { getThumbnailUrl } from './character';
 import { mergeWithUndefinedMulti } from './commons';
@@ -157,12 +158,6 @@ export function unloadStyle(name: string) {
 
 // --- API Implementation ---
 
-function deepClone<T>(obj: T): T {
-  if (obj === null || obj === undefined) return obj;
-  if (typeof obj !== 'object') return obj;
-  return JSON.parse(JSON.stringify(obj)) as T;
-}
-
 const mountableComponents: Record<MountableComponent, () => Promise<{ default: Vue.Component }>> = {
   ConnectionProfileSelector: () => import('../components/common/ConnectionProfileSelector.vue'),
   Button: () => import('../components/UI/Button.vue'),
@@ -221,20 +216,20 @@ const baseExtensionAPI: ExtensionAPI = {
     getHistory: () => {
       const store = useChatStore();
       if (!store.activeChat) throw new Error('No active chat.');
-      return deepClone(store.activeChat.messages);
+      return cloneDeep(store.activeChat.messages);
     },
     getChatInfo: () => {
       const store = useChatStore();
-      return deepClone(
+      return cloneDeep(
         store.activeChatFile ? store.chatInfos.find((info) => info.file_id === store.activeChatFile) || null : null,
       );
     },
     getAllChatInfos: () => {
-      return deepClone(useChatStore().chatInfos);
+      return cloneDeep(useChatStore().chatInfos);
     },
     getLastMessage: () => {
       const messages = useChatStore().activeChat?.messages ?? [];
-      return messages.length > 0 ? deepClone(messages[messages.length - 1]) : null;
+      return messages.length > 0 ? cloneDeep(messages[messages.length - 1]) : null;
     },
     createMessage: async (message: ApiChatMessage) => {
       if (!message.content) {
@@ -298,7 +293,7 @@ const baseExtensionAPI: ExtensionAPI = {
       chatStore.activeChat.messages.push(fullMessage);
       await nextTick();
       await eventEmitter.emit('message:created', fullMessage);
-      return deepClone(fullMessage);
+      return cloneDeep(fullMessage);
     },
     insertMessage: async (message, index) => {
       const store = useChatStore();
@@ -565,7 +560,7 @@ const baseExtensionAPI: ExtensionAPI = {
       await useChatStore().setActiveChatFile(filename);
     },
     metadata: {
-      get: () => deepClone(useChatStore().activeChat?.metadata ?? null),
+      get: () => cloneDeep(useChatStore().activeChat?.metadata ?? null),
       set: (metadata) => {
         const store = useChatStore();
         if (store.activeChat) {
@@ -598,19 +593,19 @@ const baseExtensionAPI: ExtensionAPI = {
   settings: {
     // @ts-expect-error it should return T
     get: () => console.warn('[ExtensionAPI] Scoped settings.get called via base API.'),
-    getGlobal: (path) => deepClone(useSettingsStore().getSetting(path)),
+    getGlobal: (path) => cloneDeep(useSettingsStore().getSetting(path)),
     set: () => console.warn('[ExtensionAPI] Scoped settings.set called via base API.'),
     setGlobal: (path, value) => useSettingsStore().setSetting(path, value),
     save: () => useSettingsStore().saveSettingsDebounced(),
   },
   character: {
-    getActives: () => deepClone(useCharacterStore().activeCharacters),
-    getAll: () => deepClone(useCharacterStore().characters),
+    getActives: () => cloneDeep(useCharacterStore().activeCharacters),
+    getAll: () => cloneDeep(useCharacterStore().characters),
     get: (avatar) => {
       const char = useCharacterStore().characters.find((c) => c.avatar === avatar);
-      return char ? deepClone(char) : null;
+      return char ? cloneDeep(char) : null;
     },
-    getEditing: () => deepClone(useCharacterUiStore().editFormCharacter),
+    getEditing: () => cloneDeep(useCharacterUiStore().editFormCharacter),
     create: async (character, avatarImage) => {
       const store = useCharacterStore();
       if (!avatarImage) {
@@ -624,8 +619,8 @@ const baseExtensionAPI: ExtensionAPI = {
     update: async (avatar, data) => useCharacterStore().updateAndSaveCharacter(avatar, data),
   },
   persona: {
-    getActive: () => deepClone(usePersonaStore().activePersona),
-    getAll: () => deepClone(usePersonaStore().personas),
+    getActive: () => cloneDeep(usePersonaStore().activePersona),
+    getAll: () => cloneDeep(usePersonaStore().personas),
     setActive: (avatarId) => usePersonaStore().setActivePersona(avatarId),
     updateActiveField: async (field, value) => usePersonaStore().updateActivePersonaField(field, value),
     delete: async (avatarId) => usePersonaStore().deletePersona(avatarId),
@@ -637,17 +632,17 @@ const baseExtensionAPI: ExtensionAPI = {
     getNewUid(book) {
       return useWorldInfoStore().getNewUid(book);
     },
-    getSettings: () => deepClone(useSettingsStore().settings.worldInfo),
+    getSettings: () => cloneDeep(useSettingsStore().settings.worldInfo),
     updateSettings: (settings) => {
       const store = useSettingsStore();
       store.settings.worldInfo = { ...store.settings.worldInfo, ...settings };
     },
-    getAllBookNames: () => deepClone(useWorldInfoStore().bookInfos),
+    getAllBookNames: () => cloneDeep(useWorldInfoStore().bookInfos),
     getBook: async (name) => {
       const book = await useWorldInfoStore().getBookFromCache(name, true);
-      return book ? deepClone(book) : null;
+      return book ? cloneDeep(book) : null;
     },
-    getActiveBookNames: () => deepClone(useWorldInfoStore().activeBookNames),
+    getActiveBookNames: () => cloneDeep(useWorldInfoStore().activeBookNames),
     setGlobalBookNames: (names) => {
       useWorldInfoStore().globalBookNames = names;
     },
@@ -711,13 +706,13 @@ const baseExtensionAPI: ExtensionAPI = {
       await useToolStore().unregisterTool(name);
     },
     get: (name) => {
-      return deepClone(useToolStore().getTool(name));
+      return cloneDeep(useToolStore().getTool(name));
     },
     getAll: () => {
-      return deepClone(useToolStore().toolList);
+      return cloneDeep(useToolStore().toolList);
     },
     getEnabled: () => {
-      return deepClone(useToolStore().enabledTools);
+      return cloneDeep(useToolStore().enabledTools);
     },
     isDisabled: (name) => {
       return useToolStore().isToolDisabled(name);
@@ -950,7 +945,7 @@ export function createScopedApiProxy(extensionId: string): ExtensionAPI {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     get: (path?: string): any => {
       const fullPath = path ? `extensionSettings.${extensionId}.${path}` : `extensionSettings.${extensionId}`;
-      return deepClone(settingsStore.getSetting(fullPath as SettingsPath));
+      return cloneDeep(settingsStore.getSetting(fullPath as SettingsPath));
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     set: (path: string | undefined, value: any): void => {


### PR DESCRIPTION
I did some profiling on loading a large chat and there was a _lot_ of parse and stringify in there. Using a dedicated cloneDeep function sped up things by about a third.

The cloneDeep function is already in use elsewhere in the codebase so this doesn't require adding anything new.